### PR TITLE
Use new Sandbox brand - Android specific

### DIFF
--- a/app/src/main/java/app/cash/paykit/sample/ui/ui/main/MainViewModel.kt
+++ b/app/src/main/java/app/cash/paykit/sample/ui/ui/main/MainViewModel.kt
@@ -39,8 +39,8 @@ enum class Screens {
 }
 
 /* Change these IDs and redirect URI accordingly for your own app. */
-private const val sandboxClientID = "CAS-CI_PAYKIT_MOBILE_DEMO"
-const val sandboxBrandID = "BRAND_9t4pg7c16v4lukc98bm9jxyse"
+private const val sandboxClientID = "CAS-CI_PAYKIT_ANDROID_DEMO"
+const val sandboxBrandID = "BRAND_9iw6g8mjkh75q5p5eoil6e0jf"
 
 const val redirectURI = "cashpaykitsample://checkout"
 


### PR DESCRIPTION
We want to use a separate Sandbox Brand for Android and iOS for analytics purposes. This PR sets the Sample App to use the correct Android branded merchant.

## Verification

![android-brand-sandbox](https://user-images.githubusercontent.com/416941/220462447-9c1db4a8-a548-4b60-ac53-2580778a6922.png)
